### PR TITLE
Add Flask typing API with scores and chat endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+instance/
+*.pyc
+app.db
+venv/

--- a/app.py
+++ b/app.py
@@ -1,0 +1,34 @@
+from flask import Flask
+from flask_cors import CORS
+from flask_smorest import Api
+from models import db, ma
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///app.db"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["API_TITLE"] = "Typing Game API"
+    app.config["API_VERSION"] = "v1"
+    app.config["OPENAPI_VERSION"] = "3.0.3"
+    app.config["OPENAPI_URL_PREFIX"] = "/"
+    app.config["OPENAPI_SWAGGER_UI_PATH"] = "/swagger"
+    app.config["OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
+
+    db.init_app(app)
+    ma.init_app(app)
+    CORS(app)
+    api = Api(app)
+
+    from routes import blp as api_blp
+    api.register_blueprint(api_blp)
+
+    with app.app_context():
+        db.create_all()
+
+    return app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from flask_sqlalchemy import SQLAlchemy
+from flask_marshmallow import Marshmallow
+
+
+db = SQLAlchemy()
+ma = Marshmallow()
+
+
+class Score(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String, nullable=False)
+    wpm = db.Column(db.Integer, nullable=False)
+    cpm = db.Column(db.Integer, nullable=False)
+    accuracy = db.Column(db.Float, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class ScoreSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Score
+        load_instance = True
+
+
+class ChatMessage(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String, nullable=False)
+    message = db.Column(db.String, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class ChatMessageSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = ChatMessage
+        load_instance = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+Flask-SQLAlchemy
+Flask-Marshmallow
+marshmallow
+marshmallow-sqlalchemy
+Flask-Smorest
+Flask-Cors

--- a/routes.py
+++ b/routes.py
@@ -1,0 +1,37 @@
+from flask.views import MethodView
+from flask_smorest import Blueprint
+from models import db, Score, ScoreSchema, ChatMessage, ChatMessageSchema
+
+
+blp = Blueprint("typing", __name__, url_prefix="/api", description="Typing API")
+
+
+@blp.route("/scores")
+class ScoresResource(MethodView):
+    @blp.response(200, ScoreSchema(many=True))
+    def get(self):
+        return Score.query.order_by(Score.timestamp.desc()).all()
+
+    @blp.arguments(ScoreSchema)
+    @blp.response(201, ScoreSchema)
+    def post(self, data):
+        score = Score(**data)
+        db.session.add(score)
+        db.session.commit()
+        return score
+
+
+@blp.route("/chat")
+class ChatResource(MethodView):
+    @blp.response(200, ChatMessageSchema(many=True))
+    def get(self):
+        messages = ChatMessage.query.order_by(ChatMessage.timestamp.desc()).limit(50).all()
+        return list(reversed(messages))
+
+    @blp.arguments(ChatMessageSchema)
+    @blp.response(201, ChatMessageSchema)
+    def post(self, data):
+        message = ChatMessage(**data)
+        db.session.add(message)
+        db.session.commit()
+        return message


### PR DESCRIPTION
## Summary
- add Flask application factory with CORS and OpenAPI docs
- implement SQLAlchemy models and Marshmallow schemas for scores and chat messages
- create routes for score and chat APIs

## Testing
- `python -m py_compile app.py models.py routes.py`
- `python -m venv venv && . venv/bin/activate && pip install -q -r requirements.txt && python -m py_compile app.py models.py routes.py && python - <<'PY'
from app import create_app
app = create_app()
with app.test_client() as client:
    res = client.get('/api/scores')
    print('GET /api/scores', res.status_code)
    res = client.get('/api/chat')
    print('GET /api/chat', res.status_code)
PY`


------
https://chatgpt.com/codex/tasks/task_b_689ae95c732483209a503f841c304b41